### PR TITLE
Organized gitignore file meaningfully, fixes #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,29 @@
-*.gem
-*.sublime-project
-*.sublime-workspace
-.bundle
-.DS_Store
+# borrowed from
+# https://github.com/github/gitignore.git
+
+# Jekyll.gitignore
+_site/
+.sass-cache/
+.jekyll-cache/
 .jekyll-metadata
-.sass-cache
-_asset_bundler_cache
-_site
-codekit-config.json
-node_modules
+
+# Ruby.gitignore
+*.gem
+*.rbc
+/.bundle/
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+Gemfile.lock
+.ruby-version
+.ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Node.gitignore
+node_modules/
 npm-debug.log*
+
+# Editor generated files
+.vscode
+*.swp


### PR DESCRIPTION
- Fixes #6 
- Now `.gitignore` file has ignore patterns organised meaningfully.