### PR TITLE
Fixes building jekyll docs site, closes #5

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,4 +1,18 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
-gemspec
+
+gem "github-pages", group: :jekyll_plugins
+
+gem "tzinfo-data"
+gem "wdm", "~> 0.1.0" if Gem.win_platform?
+
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+  gem "jekyll-paginate"
+  gem "jekyll-sitemap"
+  gem "jekyll-gist"
+  gem "jekyll-feed"
+  gem "jekyll-seo-tag"
+  gem "jekyll-data"
+  gem "jemoji"
+  gem "jekyll-include-cache"
+end

--- a/docs/_config.dev.yml
+++ b/docs/_config.dev.yml
@@ -1,0 +1,13 @@
+# Develop override settings
+
+url: http://localhost:4000
+
+analytics:
+  provider: false
+
+comments:
+  disqus:
+    shortname            : "lwt-dev"
+
+sass:
+  style: expanded

--- a/lone-wolf-theme.gemspec
+++ b/lone-wolf-theme.gemspec
@@ -37,6 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jemoji", "~> 0.10"
   spec.add_runtime_dependency "jekyll-include-cache", "~> 0.1"
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Now we can build `docs/_site` from the project root folder.