### PR TITLE
Added dependencies page to docs folder

### DIFF
--- a/docs/_pages/contribute.md
+++ b/docs/_pages/contribute.md
@@ -43,5 +43,10 @@ branch.
 - Use project boards for raw ideas and non code information.
 - Use github issues for project ideas implementation.
 
+## Dependencies
+
+Refer the list of [dependencies][2] to contribute to LWT.
+
 <!-- Links -->
 [lwt]: https://github.com/manid2/lone-wolf-theme
+[2]: {{ "/dependencies/" | relative_url }}

--- a/docs/_pages/dependencies.md
+++ b/docs/_pages/dependencies.md
@@ -1,0 +1,65 @@
+---
+layout: page
+title: "Dependencies"
+permalink: /dependencies/
+---
+
+List of dependencies for reference and upgrades.
+
+## Gems
+
+- "jekyll", "~> 3.8"
+- "jekyll-paginate", "~> 1.1"
+- "jekyll-sitemap", "~> 1.2"
+- "jekyll-gist", "~> 1.5"
+- "jekyll-feed", "~> 0.10"
+- "jekyll-seo-tag", "~> 2.5"
+- "jekyll-data", "~> 1.0"
+- "jemoji", "~> 0.10"
+- "jekyll-include-cache", "~> 0.1"
+
+### Gems dev deps
+
+- "bundler"
+- "rake", "~> 10.0"
+
+## Sass
+
+- animations/animate.css
+- bootstrap/bootstrap 4
+- bootstrap-social
+- bootswatch, { cerulean, spacelab, united }
+
+## Javascript
+
+### Local
+
+- banner.js
+
+### CDN
+
+- jquery-3.3.1.slim.min.js
+- popper.js, 1.14.7
+- bootstrap, 4.3.1
+- fontawesome, v5.7.2
+- analytics
+  - google analytics
+- ads
+  - google adsense
+- search-providers
+  - google custom search
+- comments-providers
+  - disqus
+
+### JS dev deps
+
+- "npm-run-all": "^4.1.5",
+- "onchange": "^5.1.3",
+- "uglify-js": "^3.4.9"
+
+## Liquid
+
+- [toc][1], 1.0.7
+
+<!-- links in the page -->
+[1]: https://github.com/allejo/jekyll-toc


### PR DESCRIPTION
docfix

For future upgrades and reference the `dependencies.md` page is added to `docs/_pages` and a link to it is added in `contribute` page.
