### PR TITLE
Updated gemspec gems to github pages versions

### DIFF
--- a/lone-wolf-theme.gemspec
+++ b/lone-wolf-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name                    = "lone-wolf-theme"
-  spec.version                 = "1.0.7"
+  spec.version                 = "1.1.0"
   spec.authors                 = ["Mani Kumar"]
 
   spec.summary                 = %q{A simple bootstrap based jekyll theme.}
@@ -30,14 +30,14 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "jekyll", "~> 3.8"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
-  spec.add_runtime_dependency "jekyll-sitemap", "~> 1.2"
+  spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
   spec.add_runtime_dependency "jekyll-gist", "~> 1.5"
-  spec.add_runtime_dependency "jekyll-feed", "~> 0.10"
-  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.5"
+  spec.add_runtime_dependency "jekyll-feed", "~> 0.13"
+  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.6"
   spec.add_runtime_dependency "jekyll-data", "~> 1.0"
-  spec.add_runtime_dependency "jemoji", "~> 0.10"
+  spec.add_runtime_dependency "jemoji", "~> 0.11"
   spec.add_runtime_dependency "jekyll-include-cache", "~> 0.1"
 
-  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Updated below gems to github pages gem verions.

- jekyll-sitemap - 1.4
- jekyll-feed - 0.13
- jekyll-seo-tag - 2.6
- jemoji - 0.11

Tested the site and docs/_site after upgrade.