### PR TITLE
Ignore tmp and wip branches in travis ci fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ deploy:
 branches:
   # blocklist
   except:
-    - tmp/*
-    - wip/*
+    - /^(?i:tmp)/.*$/
+    - /^(?i:wip)/.*$/


### PR DESCRIPTION
The fix #36 did not work, found fix in wip branch commits.